### PR TITLE
Fix pvi probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The RSCP protocol groups *Tags* (i.e. states or values) into *Namespaces* (i.e. 
   <tr>
     <td>PVI</td>
     <td>Photovoltaic Inverter</td>
-    <td>not supported (yet)</td>
+    <td>complete</td>
   </tr>
   <tr>
     <td>BAT</td>
@@ -245,6 +245,10 @@ Here is a sample script for charge limit control - it is not meant for as-is usa
 
 ## Changelog
 
+### 0.0.7-beta
+(git-kick) 
+* Complete coverage of INV namespace, including multiple strings and phases
+* started Sentry integration
 ### 0.0.6-beta
 (git-kick) 
 * Complete coverage of BAT namespace, including multiple DCBs and voltage/temperature lists


### PR DESCRIPTION
Probing a PVI which is not existing results in a response frame (this is different e.g. from BAT, where no response comes in).
This response contains an ERROR which is now handled, and the PVI maxIndex is adjusted accordingly.