### PR TITLE
Issue#117

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ Here is a sample script for charge limit control - it is not meant for as-is usa
 <a name="log"></a>
 
 ## Changelog
+### 1.0.8
+(git-kick)
+* No updates for e3dc-rscp.0.EP.PARAM_0.* - [Issue #117](https://github.com/git-kick/ioBroker.e3dc-rscp/issues/117)
+
+__Note__: DO NOT import adapter settings from a json-file created with an older version of e3dc-rscp. Instead, create a new adapter configuration from the scratch and then store it to a json-file. Reason is that importing an older json-file will delete polling interval list entries which have been added with v1.0.8 and this will invalidate the bugfix!
 ### 1.0.7
 (git-kick)
 * High CPU load on js-controller after triggering historical data - [Issue #114](https://github.com/git-kick/ioBroker.e3dc-rscp/issues/114)

--- a/io-package.json
+++ b/io-package.json
@@ -1,737 +1,737 @@
 {
-    "common": {
-        "name": "e3dc-rscp",
-        "version": "1.0.7",
-        "news": {
-            "1.0.7": {
-                "en": "Fixed DB object handling",
-                "de": "Fehler in DB Objektbehandlung behoben",
-                "ru": "Незначительные исправления",
-                "pt": "Pequenas correções",
-                "nl": "Kleine fixes",
-                "fr": "Corrections mineures",
-                "it": "Correzioni minori",
-                "es": "Correcciones menores",
-                "pl": "Drobne poprawki",
-                "zh-cn": "小修正"
-            },
-            "1.0.6": {
-                "en": "Minor fixes",
-                "de": "Kleinere Fehlerbehebungen",
-                "ru": "Незначительные исправления",
-                "pt": "Pequenas correções",
-                "nl": "Kleine fixes",
-                "fr": "Corrections mineures",
-                "it": "Correzioni minori",
-                "es": "Correcciones menores",
-                "pl": "Drobne poprawki",
-                "zh-cn": "小修正"
-            },
-            "1.0.5": {
-                "en": "Fixed SET_POWER timing issue",
-                "de": "SET_POWER Timing Problem behoben",
-                "ru": "Исправлена проблема с синхронизацией SET_POWER",
-                "pt": "Corrigido o problema de tempo SET_POWER",
-                "nl": "Vaste SET_POWER timing probleem",
-                "fr": "Correction d'un problème de synchronisation SET_POWER",
-                "it": "Risolto il problema di temporizzazione SET_POWER",
-                "es": "Solucionado el problema de temporización SET_POWER",
-                "pl": "Naprawiono problem z synchronizacją SET_POWER",
-                "zh-cn": "修正SET_POWER定时问题"
-            },
-            "1.0.4": {
-                "en": "Minor fixes",
-                "de": "Kleinere Fehlerbehebungen",
-                "ru": "Незначительные исправления",
-                "pt": "Pequenas correções",
-                "nl": "Kleine fixes",
-                "fr": "Corrections mineures",
-                "it": "Correzioni minori",
-                "es": "Correcciones menores",
-                "pl": "Drobne poprawki",
-                "zh-cn": "小修正"
-            },
-            "1.0.3": {
-                "en": "Minor fixes",
-                "de": "Kleinere Fehlerbehebungen",
-                "ru": "Незначительные исправления",
-                "pt": "Pequenas correções",
-                "nl": "Kleine fixes",
-                "fr": "Corrections mineures",
-                "it": "Correzioni minori",
-                "es": "Correcciones menores",
-                "pl": "Drobne poprawki",
-                "zh-cn": "小修正"
-            },
-            "1.0.2": {
-                "en": "Added SYS namespace (experimental)",
-                "de": "SYS Namespace hinzugefügt (experimentell)",
-                "ru": "Добавлено пространство имен SYS (экспериментальное)",
-                "pt": "Espaço de nomes de sistemas adicionado (experimental)",
-                "nl": "SYS-naamruimte toegevoegd (experimenteel)",
-                "fr": "Espace de noms SYS ajouté (expérimental)",
-                "it": "Aggiunto lo spazio dei nomi SYS (sperimentale)",
-                "es": "Espacio de nombres de sistema añadido (experimental)",
-                "pl": "Dodano przestrzeń nazw SYS (eksperymentalne)",
-                "zh-cn": "添加SYS命名空间（实验）"
-            },
-            "1.0.1": {
-                "en": "Minor technical fixes (CVE/Sentry)",
-                "de": "Kleinere technische Fehlerbehebungen (CVE/Sentry)",
-                "ru": "Незначительные технические исправления (CVE/Sentry)",
-                "pt": "Correcções técnicas menores (CVE/Sentry)",
-                "nl": "Kleine technische fixes (CVE / Sentry)",
-                "fr": "Corrections techniques mineures (CVE/Sentry)",
-                "it": "Correzioni tecniche minori (CVE / Sentry)",
-                "es": "Correcciones técnicas menores (CVE / Sentry)",
-                "pl": "Drobne poprawki techniczne (CVE / Sentry)",
-                "zh-cn": "次要技术修复（CVE/Sentry）"
-            },
-            "1.0.0": {
-                "en": "Initial public release",
-                "de": "Initial Public Release",
-                "ru": "Первоначальный публичный релиз",
-                "pt": "Publicação pública inicial",
-                "nl": "Eerste publieke publicatie",
-                "fr": "Diffusion publique initiale",
-                "it": "Rilascio pubblico iniziale",
-                "es": "Lanzamiento inicial",
-                "pl": "Pierwsze publiczne wydanie",
-                "zh-cn": "首次公开发行"
-            }
-        },
-        "title": "E3/DC RSCP",
-        "titleLang": {
-            "en": "E3/DC RSCP",
-            "de": "E3/DC RSCP",
-            "ru": "E3/DC RSCP",
-            "pt": "E3/DC RSCP",
-            "nl": "E3/DC RSCP",
-            "fr": "E3/DC RSCP",
-            "it": "E3/DC RSCP",
-            "es": "E3/DC RSCP",
-            "pl": "E3/DC RSCP",
-            "zh-cn": "E3/DC RSCP"
-        },
-        "desc": {
-            "en": "Control E3/DC power station using RSCP protocol",
-            "de": "Steuern Sie das E3/DC-Kraftwerk mithilfe des RSCP-Protokolls",
-            "ru": "Управление электростанцией E3/DC по протоколу RSCP",
-            "pt": "Controle da estação de energia E3/DC usando o protocolo RSCP",
-            "nl": "Bedien de E3/DC-krachtcentrale met behulp van het RSCP-protocol",
-            "fr": "Contrôlez la centrale électrique E3/DC en utilisant le protocole RSCP",
-            "it": "Controllare la centrale E3/DC utilizzando il protocollo RSCP",
-            "es": "Control de la central eléctrica E3/DC mediante protocolo RSCP",
-            "pl": "Sterowanie elektrownią E3/DC za pomocą protokołu RSCP",
-            "zh-cn": "使用RSCP协议控制E3/DC电站"
-        },
-        "authors": [
-            "Ulrich Kick <iobroker@kick-web.de>"
-        ],
-        "keywords": [
-            "E3/DC",
-            "power station",
-            "energy",
-            "RSCP"
-        ],
-        "license": "GPL-3.0-only",
-        "platform": "Javascript/Node.js",
-        "main": "main.js",
-        "icon": "e3dc-rscp.png",
-        "enabled": true,
-        "extIcon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
-        "readme": "https://github.com/git-kick/ioBroker.e3dc-rscp/blob/master/README.md",
-        "loglevel": "info",
-        "mode": "daemon",
-        "type": "energy",
-        "compact": true,
-        "connectionType": "local",
-        "dataSource": "poll",
-        "materialize": true,
-        "materializeTab": false,
-        "dependencies": [
-            {
-                "js-controller": ">=2.0.0"
-            }
-        ]
+  "common": {
+    "name": "e3dc-rscp",
+    "version": "1.0.7",
+    "news": {
+      "1.0.7": {
+        "en": "Fixed DB object handling",
+        "de": "Fehler in DB Objektbehandlung behoben",
+        "ru": "Незначительные исправления",
+        "pt": "Pequenas correções",
+        "nl": "Kleine fixes",
+        "fr": "Corrections mineures",
+        "it": "Correzioni minori",
+        "es": "Correcciones menores",
+        "pl": "Drobne poprawki",
+        "zh-cn": "小修正"
+      },
+      "1.0.6": {
+        "en": "Minor fixes",
+        "de": "Kleinere Fehlerbehebungen",
+        "ru": "Незначительные исправления",
+        "pt": "Pequenas correções",
+        "nl": "Kleine fixes",
+        "fr": "Corrections mineures",
+        "it": "Correzioni minori",
+        "es": "Correcciones menores",
+        "pl": "Drobne poprawki",
+        "zh-cn": "小修正"
+      },
+      "1.0.5": {
+        "en": "Fixed SET_POWER timing issue",
+        "de": "SET_POWER Timing Problem behoben",
+        "ru": "Исправлена проблема с синхронизацией SET_POWER",
+        "pt": "Corrigido o problema de tempo SET_POWER",
+        "nl": "Vaste SET_POWER timing probleem",
+        "fr": "Correction d'un problème de synchronisation SET_POWER",
+        "it": "Risolto il problema di temporizzazione SET_POWER",
+        "es": "Solucionado el problema de temporización SET_POWER",
+        "pl": "Naprawiono problem z synchronizacją SET_POWER",
+        "zh-cn": "修正SET_POWER定时问题"
+      },
+      "1.0.4": {
+        "en": "Minor fixes",
+        "de": "Kleinere Fehlerbehebungen",
+        "ru": "Незначительные исправления",
+        "pt": "Pequenas correções",
+        "nl": "Kleine fixes",
+        "fr": "Corrections mineures",
+        "it": "Correzioni minori",
+        "es": "Correcciones menores",
+        "pl": "Drobne poprawki",
+        "zh-cn": "小修正"
+      },
+      "1.0.3": {
+        "en": "Minor fixes",
+        "de": "Kleinere Fehlerbehebungen",
+        "ru": "Незначительные исправления",
+        "pt": "Pequenas correções",
+        "nl": "Kleine fixes",
+        "fr": "Corrections mineures",
+        "it": "Correzioni minori",
+        "es": "Correcciones menores",
+        "pl": "Drobne poprawki",
+        "zh-cn": "小修正"
+      },
+      "1.0.2": {
+        "en": "Added SYS namespace (experimental)",
+        "de": "SYS Namespace hinzugefügt (experimentell)",
+        "ru": "Добавлено пространство имен SYS (экспериментальное)",
+        "pt": "Espaço de nomes de sistemas adicionado (experimental)",
+        "nl": "SYS-naamruimte toegevoegd (experimenteel)",
+        "fr": "Espace de noms SYS ajouté (expérimental)",
+        "it": "Aggiunto lo spazio dei nomi SYS (sperimentale)",
+        "es": "Espacio de nombres de sistema añadido (experimental)",
+        "pl": "Dodano przestrzeń nazw SYS (eksperymentalne)",
+        "zh-cn": "添加SYS命名空间（实验）"
+      },
+      "1.0.1": {
+        "en": "Minor technical fixes (CVE/Sentry)",
+        "de": "Kleinere technische Fehlerbehebungen (CVE/Sentry)",
+        "ru": "Незначительные технические исправления (CVE/Sentry)",
+        "pt": "Correcções técnicas menores (CVE/Sentry)",
+        "nl": "Kleine technische fixes (CVE / Sentry)",
+        "fr": "Corrections techniques mineures (CVE/Sentry)",
+        "it": "Correzioni tecniche minori (CVE / Sentry)",
+        "es": "Correcciones técnicas menores (CVE / Sentry)",
+        "pl": "Drobne poprawki techniczne (CVE / Sentry)",
+        "zh-cn": "次要技术修复（CVE/Sentry）"
+      },
+      "1.0.0": {
+        "en": "Initial public release",
+        "de": "Initial Public Release",
+        "ru": "Первоначальный публичный релиз",
+        "pt": "Publicação pública inicial",
+        "nl": "Eerste publieke publicatie",
+        "fr": "Diffusion publique initiale",
+        "it": "Rilascio pubblico iniziale",
+        "es": "Lanzamiento inicial",
+        "pl": "Pierwsze publiczne wydanie",
+        "zh-cn": "首次公开发行"
+      }
     },
-    "native": {
-        "e3dc_ip": "192.168.178.1",
-        "e3dc_port": 5033,
-        "rscp_password": "",
-        "portal_user": "",
-        "portal_password": "",
-        "polling_intervals": [
-            {
-                "tag": "TAG_EMS_REQ_POWER_PV",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_BAT",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_HOME",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_GRID",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_ADD",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_AUTARKY",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_SELF_CONSUMPTION",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_BAT_SOC",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_COUPLING_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_STORED_ERRORS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_MODE",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_BALANCED_PHASES",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_INSTALLED_PEAK_POWER",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_EMS_REQ_DERATE_AT_PERCENT_VALUE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_EMS_REQ_DERATE_AT_POWER_VALUE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_WB_ALL",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_WB_SOLAR",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_EXT_SRC_AVAILABLE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_EMS_REQ_STATUS",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EMS_REQ_USED_CHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_BAT_CHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_DCDC_CHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_USER_CHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_USED_DISCHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_BAT_DISCHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_DCDC_DISCHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_USER_DISCHARGE_LIMIT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_REMAINING_BAT_CHARGE_POWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_REMAINING_BAT_DISCHARGE_POWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_EMERGENCY_POWER_STATUS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_BATTERY_TO_CAR_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_BATTERY_BEFORE_CAR_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_GET_IDLE_PERIODS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_GET_POWER_SETTINGS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_GET_MANUAL_CHARGE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_EMERGENCYPOWER_TEST_STATUS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_GET_SYS_SPECS",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_EMS_REQ_POWER_PV_AC_OUT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EMS_REQ_ALIVE",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_EP_REQ_IS_READY_FOR_SWITCH",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EP_REQ_IS_GRID_CONNECTED",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EP_REQ_IS_ISLAND_GRID",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EP_REQ_IS_INVALID_STATE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EP_REQ_IS_POSSIBLE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_EP_REQ_EP_RESERVE",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_PVI_REQ_ON_GRID",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_STATE",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_PVI_REQ_LAST_ERROR",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_TYPE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_PVI_REQ_VOLTAGE_MONITORING",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_FREQUENCY_UNDER_OVER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_SYSTEM_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_POWER_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_TEMPERATURE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_TEMPERATURE_COUNT",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_PVI_REQ_MAX_TEMPERATURE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_MIN_TEMPERATURE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_DEVICE_STATE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_SERIAL_NUMBER",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_PVI_REQ_VERSION",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_MAX_PHASE_COUNT",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_POWER",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_VOLTAGE",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_CURRENT",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_APPARENTPOWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_REACTIVEPOWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_ENERGY_ALL",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_MAX_APPARENTPOWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_AC_ENERGY_GRID_CONSUMPTION",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_DC_POWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_DC_VOLTAGE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_DC_CURRENT",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_PVI_REQ_DC_STRING_ENERGY_ALL",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_MAX_BAT_VOLTAGE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_MAX_CHARGE_CURRENT",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_EOD_VOLTAGE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_MAX_DISCHARGE_CURRENT",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_CHARGE_CYCLES",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_TERMINAL_VOLTAGE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_DEVICE_NAME",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_DCB_COUNT",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_RSOC_REAL",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_ASOC",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_FCC",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_RC",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_MAX_DCB_CELL_TEMPERATURE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_MIN_DCB_CELL_TEMPERATURE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_DCB_ALL_CELL_TEMPERATURES",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_DCB_ALL_CELL_VOLTAGES",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_READY_FOR_SHUTDOWN",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_INFO",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_TRAINING_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_USABLE_CAPACITY",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_USABLE_REMAINING_CAPACITY",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_DCB_INFO",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_SPECIFICATION",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_INTERNALS",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_BAT_REQ_TOTAL_USE_TIME",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_TOTAL_DISCHARGE_TIME",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_BAT_REQ_DEVICE_STATE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_SYS_REQ_IS_SYSTEM_REBOOTING",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_WB_REQ_STATUS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_ENERGY_ALL",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_ENERGY_SOLAR",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_SOC",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_STATUS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_ERROR_CODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_APP_SOFTWARE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_BOOTLOADER_SOFTWARE",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_HW_VERSION",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_FLASH_VERSION",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_DEVICE_ID",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_DEVICE_STATE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_POWER_L1",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_POWER_L2",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_POWER_L3",
-                "interval": "S"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_ACTIVE_PHASES",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_MODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_ENERGY_L1",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_ENERGY_L2",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_ENERGY_L3",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_DEVICE_ID",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_ERROR_CODE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_DEVICE_STATE",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_FIRMWARE_VERSION",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_DIAG_INFOS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_DIAG_WARNINGS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_DIAG_ERRORS",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_DIAG_TEMP_1",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_DIAG_TEMP_2",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PM_MAX_PHASE_POWER",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_DEVICE_NAME",
-                "interval": "L"
-            },
-            {
-                "tag": "TAG_WB_REQ_EXTERN_DATA_SUN",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_EXTERN_DATA_NET",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_EXTERN_DATA_ALL",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_EXTERN_DATA_ALG",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PARAM_1",
-                "interval": "M"
-            },
-            {
-                "tag": "TAG_WB_REQ_PARAM_2",
-                "interval": "M"
-            }
-        ],
-        "polling_interval_short": 30,
-        "polling_interval_medium": 5,
-        "polling_interval_long": 12,
-        "setpower_interval": 10,
-        "send_tuple_delay": 10,
-        "query_bat": "true",
-        "query_ems": "true",
-        "query_ep": "true",
-        "query_pvi": "true",
-        "query_sys": "true",
-        "query_wb": "true",
-        "query_db": "true"
+    "title": "E3/DC RSCP",
+    "titleLang": {
+      "en": "E3/DC RSCP",
+      "de": "E3/DC RSCP",
+      "ru": "E3/DC RSCP",
+      "pt": "E3/DC RSCP",
+      "nl": "E3/DC RSCP",
+      "fr": "E3/DC RSCP",
+      "it": "E3/DC RSCP",
+      "es": "E3/DC RSCP",
+      "pl": "E3/DC RSCP",
+      "zh-cn": "E3/DC RSCP"
     },
-    "objects": [],
-    "instanceObjects": []
+    "desc": {
+      "en": "Control E3/DC power station using RSCP protocol",
+      "de": "Steuern Sie das E3/DC-Kraftwerk mithilfe des RSCP-Protokolls",
+      "ru": "Управление электростанцией E3/DC по протоколу RSCP",
+      "pt": "Controle da estação de energia E3/DC usando o protocolo RSCP",
+      "nl": "Bedien de E3/DC-krachtcentrale met behulp van het RSCP-protocol",
+      "fr": "Contrôlez la centrale électrique E3/DC en utilisant le protocole RSCP",
+      "it": "Controllare la centrale E3/DC utilizzando il protocollo RSCP",
+      "es": "Control de la central eléctrica E3/DC mediante protocolo RSCP",
+      "pl": "Sterowanie elektrownią E3/DC za pomocą protokołu RSCP",
+      "zh-cn": "使用RSCP协议控制E3/DC电站"
+    },
+    "authors": [
+      "Ulrich Kick <iobroker@kick-web.de>"
+    ],
+    "keywords": [
+      "E3/DC",
+      "power station",
+      "energy",
+      "RSCP"
+    ],
+    "license": "GPL-3.0-only",
+    "platform": "Javascript/Node.js",
+    "main": "main.js",
+    "icon": "e3dc-rscp.png",
+    "enabled": true,
+    "extIcon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
+    "readme": "https://github.com/git-kick/ioBroker.e3dc-rscp/blob/master/README.md",
+    "loglevel": "info",
+    "mode": "daemon",
+    "type": "energy",
+    "compact": true,
+    "connectionType": "local",
+    "dataSource": "poll",
+    "materialize": true,
+    "materializeTab": false,
+    "dependencies": [
+      {
+        "js-controller": ">=2.0.0"
+      }
+    ]  
+  },
+  "native": {
+    "e3dc_ip": "192.168.178.1",
+    "e3dc_port": 5033,
+    "rscp_password": "",
+    "portal_user": "",
+    "portal_password": "",
+    "polling_intervals": [
+      {
+        "tag": "TAG_EMS_REQ_POWER_PV",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_BAT",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_HOME",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_GRID",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_ADD",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_AUTARKY",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_SELF_CONSUMPTION",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_BAT_SOC",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_COUPLING_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_STORED_ERRORS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_MODE",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_BALANCED_PHASES",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_INSTALLED_PEAK_POWER",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_EMS_REQ_DERATE_AT_PERCENT_VALUE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_EMS_REQ_DERATE_AT_POWER_VALUE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_WB_ALL",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_WB_SOLAR",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_EXT_SRC_AVAILABLE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_EMS_REQ_STATUS",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EMS_REQ_USED_CHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_BAT_CHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_DCDC_CHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_USER_CHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_USED_DISCHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_BAT_DISCHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_DCDC_DISCHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_USER_DISCHARGE_LIMIT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_REMAINING_BAT_CHARGE_POWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_REMAINING_BAT_DISCHARGE_POWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_EMERGENCY_POWER_STATUS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_BATTERY_TO_CAR_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_BATTERY_BEFORE_CAR_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_GET_IDLE_PERIODS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_GET_POWER_SETTINGS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_GET_MANUAL_CHARGE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_EMERGENCYPOWER_TEST_STATUS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_GET_SYS_SPECS",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_EMS_REQ_POWER_PV_AC_OUT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EMS_REQ_ALIVE",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_EP_REQ_IS_READY_FOR_SWITCH",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EP_REQ_IS_GRID_CONNECTED",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EP_REQ_IS_ISLAND_GRID",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EP_REQ_IS_INVALID_STATE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EP_REQ_IS_POSSIBLE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_EP_REQ_EP_RESERVE",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_PVI_REQ_ON_GRID",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_STATE",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_PVI_REQ_LAST_ERROR",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_TYPE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_PVI_REQ_VOLTAGE_MONITORING",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_FREQUENCY_UNDER_OVER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_SYSTEM_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_POWER_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_TEMPERATURE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_TEMPERATURE_COUNT",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_PVI_REQ_MAX_TEMPERATURE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_MIN_TEMPERATURE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_DEVICE_STATE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_SERIAL_NUMBER",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_PVI_REQ_VERSION",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_MAX_PHASE_COUNT",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_POWER",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_VOLTAGE",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_CURRENT",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_APPARENTPOWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_REACTIVEPOWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_ENERGY_ALL",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_MAX_APPARENTPOWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_AC_ENERGY_GRID_CONSUMPTION",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_DC_POWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_DC_VOLTAGE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_DC_CURRENT",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_PVI_REQ_DC_STRING_ENERGY_ALL",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_MAX_BAT_VOLTAGE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_MAX_CHARGE_CURRENT",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_EOD_VOLTAGE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_MAX_DISCHARGE_CURRENT",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_CHARGE_CYCLES",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_TERMINAL_VOLTAGE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_DEVICE_NAME",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_DCB_COUNT",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_RSOC_REAL",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_ASOC",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_FCC",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_RC",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_MAX_DCB_CELL_TEMPERATURE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_MIN_DCB_CELL_TEMPERATURE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_DCB_ALL_CELL_TEMPERATURES",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_DCB_ALL_CELL_VOLTAGES",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_READY_FOR_SHUTDOWN",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_INFO",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_TRAINING_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_USABLE_CAPACITY",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_USABLE_REMAINING_CAPACITY",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_DCB_INFO",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_SPECIFICATION",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_INTERNALS",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_BAT_REQ_TOTAL_USE_TIME",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_TOTAL_DISCHARGE_TIME",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_DEVICE_STATE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_SYS_REQ_IS_SYSTEM_REBOOTING",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_WB_REQ_STATUS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_ENERGY_ALL",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_ENERGY_SOLAR",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_SOC",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_STATUS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_ERROR_CODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_APP_SOFTWARE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_BOOTLOADER_SOFTWARE",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_HW_VERSION",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_FLASH_VERSION",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_DEVICE_ID",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_DEVICE_STATE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_POWER_L1",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_POWER_L2",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_POWER_L3",
+        "interval": "S"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_ACTIVE_PHASES",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_MODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_ENERGY_L1",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_ENERGY_L2",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_ENERGY_L3",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_DEVICE_ID",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_ERROR_CODE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_DEVICE_STATE",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_FIRMWARE_VERSION",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_DIAG_INFOS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_DIAG_WARNINGS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_DIAG_ERRORS",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_DIAG_TEMP_1",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_DIAG_TEMP_2",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PM_MAX_PHASE_POWER",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_DEVICE_NAME",
+        "interval": "L"
+      },
+      {
+        "tag": "TAG_WB_REQ_EXTERN_DATA_SUN",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_EXTERN_DATA_NET",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_EXTERN_DATA_ALL",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_EXTERN_DATA_ALG",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PARAM_1",
+        "interval": "M"
+      },
+      {
+        "tag": "TAG_WB_REQ_PARAM_2",
+        "interval": "M"
+      }
+    ],
+    "polling_interval_short": 30,
+    "polling_interval_medium": 5,
+    "polling_interval_long": 12,
+    "setpower_interval": 10,
+    "send_tuple_delay": 10,
+    "query_bat": "true",
+    "query_ems": "true",
+    "query_ep": "true",
+    "query_pvi": "true",
+    "query_sys": "true",
+    "query_wb": "true",
+    "query_db": "true"
+  },
+  "objects": [],
+  "instanceObjects": []
 }

--- a/io-package.json
+++ b/io-package.json
@@ -1,745 +1,757 @@
 {
-  "common": {
-    "name": "e3dc-rscp",
-    "version": "1.0.7",
-    "news": {
-      "1.0.7": {
-        "en": "Fixed DB object handling",
-        "de": "Fehler in DB Objektbehandlung behoben",
-        "ru": "Незначительные исправления",
-        "pt": "Pequenas correções",
-        "nl": "Kleine fixes",
-        "fr": "Corrections mineures",
-        "it": "Correzioni minori",
-        "es": "Correcciones menores",
-        "pl": "Drobne poprawki",
-        "zh-cn": "小修正"
-      },
-      "1.0.6": {
-        "en": "Minor fixes",
-        "de": "Kleinere Fehlerbehebungen",
-        "ru": "Незначительные исправления",
-        "pt": "Pequenas correções",
-        "nl": "Kleine fixes",
-        "fr": "Corrections mineures",
-        "it": "Correzioni minori",
-        "es": "Correcciones menores",
-        "pl": "Drobne poprawki",
-        "zh-cn": "小修正"
-      },
-      "1.0.5": {
-        "en": "Fixed SET_POWER timing issue",
-        "de": "SET_POWER Timing Problem behoben",
-        "ru": "Исправлена проблема с синхронизацией SET_POWER",
-        "pt": "Corrigido o problema de tempo SET_POWER",
-        "nl": "Vaste SET_POWER timing probleem",
-        "fr": "Correction d'un problème de synchronisation SET_POWER",
-        "it": "Risolto il problema di temporizzazione SET_POWER",
-        "es": "Solucionado el problema de temporización SET_POWER",
-        "pl": "Naprawiono problem z synchronizacją SET_POWER",
-        "zh-cn": "修正SET_POWER定时问题"
-      },
-      "1.0.4": {
-        "en": "Minor fixes",
-        "de": "Kleinere Fehlerbehebungen",
-        "ru": "Незначительные исправления",
-        "pt": "Pequenas correções",
-        "nl": "Kleine fixes",
-        "fr": "Corrections mineures",
-        "it": "Correzioni minori",
-        "es": "Correcciones menores",
-        "pl": "Drobne poprawki",
-        "zh-cn": "小修正"
-      },
-      "1.0.3": {
-        "en": "Minor fixes",
-        "de": "Kleinere Fehlerbehebungen",
-        "ru": "Незначительные исправления",
-        "pt": "Pequenas correções",
-        "nl": "Kleine fixes",
-        "fr": "Corrections mineures",
-        "it": "Correzioni minori",
-        "es": "Correcciones menores",
-        "pl": "Drobne poprawki",
-        "zh-cn": "小修正"
-      },
-      "1.0.2": {
-        "en": "Added SYS namespace (experimental)",
-        "de": "SYS Namespace hinzugefügt (experimentell)",
-        "ru": "Добавлено пространство имен SYS (экспериментальное)",
-        "pt": "Espaço de nomes de sistemas adicionado (experimental)",
-        "nl": "SYS-naamruimte toegevoegd (experimenteel)",
-        "fr": "Espace de noms SYS ajouté (expérimental)",
-        "it": "Aggiunto lo spazio dei nomi SYS (sperimentale)",
-        "es": "Espacio de nombres de sistema añadido (experimental)",
-        "pl": "Dodano przestrzeń nazw SYS (eksperymentalne)",
-        "zh-cn": "添加SYS命名空间（实验）"
-      },
-      "1.0.1": {
-        "en": "Minor technical fixes (CVE/Sentry)",
-        "de": "Kleinere technische Fehlerbehebungen (CVE/Sentry)",
-        "ru": "Незначительные технические исправления (CVE/Sentry)",
-        "pt": "Correcções técnicas menores (CVE/Sentry)",
-        "nl": "Kleine technische fixes (CVE / Sentry)",
-        "fr": "Corrections techniques mineures (CVE/Sentry)",
-        "it": "Correzioni tecniche minori (CVE / Sentry)",
-        "es": "Correcciones técnicas menores (CVE / Sentry)",
-        "pl": "Drobne poprawki techniczne (CVE / Sentry)",
-        "zh-cn": "次要技术修复（CVE/Sentry）"
-      },
-      "1.0.0": {
-        "en": "Initial public release",
-        "de": "Initial Public Release",
-        "ru": "Первоначальный публичный релиз",
-        "pt": "Publicação pública inicial",
-        "nl": "Eerste publieke publicatie",
-        "fr": "Diffusion publique initiale",
-        "it": "Rilascio pubblico iniziale",
-        "es": "Lanzamiento inicial",
-        "pl": "Pierwsze publiczne wydanie",
-        "zh-cn": "首次公开发行"
-      }
+    "common": {
+        "name": "e3dc-rscp",
+        "version": "1.0.8",
+        "news": {
+            "1.0.8": {
+                "en": "Fixed polling e3dc-rscp.0.EP.PARAM_0.*",
+                "de": "Stoppende Abfrage für e3dc-rscp.0.EP.PARAM_0.* behoben",
+                "ru": "Исправлен опрос e3dc-rscp.0.EP.PARAM_0.*",
+                "pt": "Corrigida a sondagem e3dc-rscp.0.EP.PARAM_0.*",
+                "nl": "Vaste polling e3dc-rscp.0.EP.PARAM_0.*",
+                "fr": "Interrogation fixe e3dc-rscp.0.EP.PARAM_0.*",
+                "it": "Risolto il problema con il polling e3dc-rscp.0.EP.PARAM_0.*",
+                "es": "Sondeo fijo e3dc-rscp.0.EP.PARAM_0.*",
+                "pl": "Naprawiono odpytywanie e3dc-rscp.0.EP.PARAM_0.*",
+                "zh-cn": "固定轮询 e3dc-rscp.0.EP.PARAM_0.*"
+            },
+            "1.0.7": {
+                "en": "Fixed DB object handling",
+                "de": "Fehler in DB Objektbehandlung behoben",
+                "ru": "Исправлена ​​работа с объектами БД.",
+                "pt": "Manipulação de objetos de banco de dados fixo",
+                "nl": "Vaste DB-objectafhandeling",
+                "fr": "Gestion fixe des objets DB",
+                "it": "Risolto il problema con la gestione degli oggetti DB",
+                "es": "Manejo fijo de objetos DB",
+                "pl": "Naprawiono obsługę obiektów DB",
+                "zh-cn": "固定数据库对象处理"
+            },
+            "1.0.6": {
+                "en": "Minor fixes",
+                "de": "Kleinere Fehlerbehebungen",
+                "ru": "Незначительные исправления",
+                "pt": "Pequenas correções",
+                "nl": "Kleine fixes",
+                "fr": "Corrections mineures",
+                "it": "Correzioni minori",
+                "es": "Correcciones menores",
+                "pl": "Drobne poprawki",
+                "zh-cn": "小修正"
+            },
+            "1.0.5": {
+                "en": "Fixed SET_POWER timing issue",
+                "de": "SET_POWER Timing Problem behoben",
+                "ru": "Исправлена проблема с синхронизацией SET_POWER",
+                "pt": "Corrigido o problema de tempo SET_POWER",
+                "nl": "Vaste SET_POWER timing probleem",
+                "fr": "Correction d'un problème de synchronisation SET_POWER",
+                "it": "Risolto il problema di temporizzazione SET_POWER",
+                "es": "Solucionado el problema de temporización SET_POWER",
+                "pl": "Naprawiono problem z synchronizacją SET_POWER",
+                "zh-cn": "修正SET_POWER定时问题"
+            },
+            "1.0.4": {
+                "en": "Minor fixes",
+                "de": "Kleinere Fehlerbehebungen",
+                "ru": "Незначительные исправления",
+                "pt": "Pequenas correções",
+                "nl": "Kleine fixes",
+                "fr": "Corrections mineures",
+                "it": "Correzioni minori",
+                "es": "Correcciones menores",
+                "pl": "Drobne poprawki",
+                "zh-cn": "小修正"
+            },
+            "1.0.3": {
+                "en": "Minor fixes",
+                "de": "Kleinere Fehlerbehebungen",
+                "ru": "Незначительные исправления",
+                "pt": "Pequenas correções",
+                "nl": "Kleine fixes",
+                "fr": "Corrections mineures",
+                "it": "Correzioni minori",
+                "es": "Correcciones menores",
+                "pl": "Drobne poprawki",
+                "zh-cn": "小修正"
+            },
+            "1.0.2": {
+                "en": "Added SYS namespace (experimental)",
+                "de": "SYS Namespace hinzugefügt (experimentell)",
+                "ru": "Добавлено пространство имен SYS (экспериментальное)",
+                "pt": "Espaço de nomes de sistemas adicionado (experimental)",
+                "nl": "SYS-naamruimte toegevoegd (experimenteel)",
+                "fr": "Espace de noms SYS ajouté (expérimental)",
+                "it": "Aggiunto lo spazio dei nomi SYS (sperimentale)",
+                "es": "Espacio de nombres de sistema añadido (experimental)",
+                "pl": "Dodano przestrzeń nazw SYS (eksperymentalne)",
+                "zh-cn": "添加SYS命名空间（实验）"
+            },
+            "1.0.1": {
+                "en": "Minor technical fixes (CVE/Sentry)",
+                "de": "Kleinere technische Fehlerbehebungen (CVE/Sentry)",
+                "ru": "Незначительные технические исправления (CVE/Sentry)",
+                "pt": "Correcções técnicas menores (CVE/Sentry)",
+                "nl": "Kleine technische fixes (CVE / Sentry)",
+                "fr": "Corrections techniques mineures (CVE/Sentry)",
+                "it": "Correzioni tecniche minori (CVE / Sentry)",
+                "es": "Correcciones técnicas menores (CVE / Sentry)",
+                "pl": "Drobne poprawki techniczne (CVE / Sentry)",
+                "zh-cn": "次要技术修复（CVE/Sentry）"
+            },
+            "1.0.0": {
+                "en": "Initial public release",
+                "de": "Initial Public Release",
+                "ru": "Первоначальный публичный релиз",
+                "pt": "Publicação pública inicial",
+                "nl": "Eerste publieke publicatie",
+                "fr": "Diffusion publique initiale",
+                "it": "Rilascio pubblico iniziale",
+                "es": "Lanzamiento inicial",
+                "pl": "Pierwsze publiczne wydanie",
+                "zh-cn": "首次公开发行"
+            }
+        },
+        "title": "E3/DC RSCP",
+        "titleLang": {
+            "en": "E3/DC RSCP",
+            "de": "E3/DC RSCP",
+            "ru": "E3/DC RSCP",
+            "pt": "E3/DC RSCP",
+            "nl": "E3/DC RSCP",
+            "fr": "E3/DC RSCP",
+            "it": "E3/DC RSCP",
+            "es": "E3/DC RSCP",
+            "pl": "E3/DC RSCP",
+            "zh-cn": "E3/DC RSCP"
+        },
+        "desc": {
+            "en": "Control E3/DC power station using RSCP protocol",
+            "de": "Steuern Sie das E3/DC-Kraftwerk mithilfe des RSCP-Protokolls",
+            "ru": "Управление электростанцией E3/DC по протоколу RSCP",
+            "pt": "Controle da estação de energia E3/DC usando o protocolo RSCP",
+            "nl": "Bedien de E3/DC-krachtcentrale met behulp van het RSCP-protocol",
+            "fr": "Contrôlez la centrale électrique E3/DC en utilisant le protocole RSCP",
+            "it": "Controllare la centrale E3/DC utilizzando il protocollo RSCP",
+            "es": "Control de la central eléctrica E3/DC mediante protocolo RSCP",
+            "pl": "Sterowanie elektrownią E3/DC za pomocą protokołu RSCP",
+            "zh-cn": "使用RSCP协议控制E3/DC电站"
+        },
+        "authors": [
+            "Ulrich Kick <iobroker@kick-web.de>"
+        ],
+        "keywords": [
+            "E3/DC",
+            "power station",
+            "energy",
+            "RSCP"
+        ],
+        "license": "GPL-3.0-only",
+        "platform": "Javascript/Node.js",
+        "main": "main.js",
+        "icon": "e3dc-rscp.png",
+        "enabled": true,
+        "extIcon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
+        "readme": "https://github.com/git-kick/ioBroker.e3dc-rscp/blob/master/README.md",
+        "loglevel": "info",
+        "mode": "daemon",
+        "type": "energy",
+        "compact": true,
+        "connectionType": "local",
+        "dataSource": "poll",
+        "materialize": true,
+        "materializeTab": false,
+        "dependencies": [
+            {
+                "js-controller": ">=2.0.0"
+            }
+        ]
     },
-    "title": "E3/DC RSCP",
-    "titleLang": {
-      "en": "E3/DC RSCP",
-      "de": "E3/DC RSCP",
-      "ru": "E3/DC RSCP",
-      "pt": "E3/DC RSCP",
-      "nl": "E3/DC RSCP",
-      "fr": "E3/DC RSCP",
-      "it": "E3/DC RSCP",
-      "es": "E3/DC RSCP",
-      "pl": "E3/DC RSCP",
-      "zh-cn": "E3/DC RSCP"
+    "native": {
+        "e3dc_ip": "192.168.178.1",
+        "e3dc_port": 5033,
+        "rscp_password": "",
+        "portal_user": "",
+        "portal_password": "",
+        "polling_intervals": [
+            {
+                "tag": "TAG_EMS_REQ_POWER_PV",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_BAT",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_HOME",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_GRID",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_ADD",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_AUTARKY",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_SELF_CONSUMPTION",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_BAT_SOC",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_COUPLING_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_STORED_ERRORS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_MODE",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_BALANCED_PHASES",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_INSTALLED_PEAK_POWER",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_EMS_REQ_DERATE_AT_PERCENT_VALUE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_EMS_REQ_DERATE_AT_POWER_VALUE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_WB_ALL",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_WB_SOLAR",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_EXT_SRC_AVAILABLE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_EMS_REQ_STATUS",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EMS_REQ_USED_CHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_BAT_CHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_DCDC_CHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_USER_CHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_USED_DISCHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_BAT_DISCHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_DCDC_DISCHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_USER_DISCHARGE_LIMIT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_REMAINING_BAT_CHARGE_POWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_REMAINING_BAT_DISCHARGE_POWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_EMERGENCY_POWER_STATUS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_BATTERY_TO_CAR_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_BATTERY_BEFORE_CAR_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_GET_IDLE_PERIODS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_GET_POWER_SETTINGS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_GET_MANUAL_CHARGE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_EMERGENCYPOWER_TEST_STATUS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_GET_SYS_SPECS",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_EMS_REQ_POWER_PV_AC_OUT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EMS_REQ_ALIVE",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_EP_REQ_IS_READY_FOR_SWITCH",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EP_REQ_IS_GRID_CONNECTED",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EP_REQ_IS_ISLAND_GRID",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EP_REQ_IS_INVALID_STATE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EP_REQ_IS_POSSIBLE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_EP_REQ_EP_RESERVE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_ON_GRID",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_STATE",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_PVI_REQ_LAST_ERROR",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_TYPE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_PVI_REQ_VOLTAGE_MONITORING",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_FREQUENCY_UNDER_OVER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_SYSTEM_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_POWER_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_TEMPERATURE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_TEMPERATURE_COUNT",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_PVI_REQ_MAX_TEMPERATURE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_MIN_TEMPERATURE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_DEVICE_STATE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_SERIAL_NUMBER",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_PVI_REQ_VERSION",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_MAX_PHASE_COUNT",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_POWER",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_VOLTAGE",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_CURRENT",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_APPARENTPOWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_REACTIVEPOWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_ENERGY_ALL",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_MAX_APPARENTPOWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_AC_ENERGY_GRID_CONSUMPTION",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_DC_POWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_DC_VOLTAGE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_DC_CURRENT",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_PVI_REQ_DC_STRING_ENERGY_ALL",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_INFO",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_MAX_BAT_VOLTAGE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_MAX_CHARGE_CURRENT",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_EOD_VOLTAGE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_MAX_DISCHARGE_CURRENT",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_CHARGE_CYCLES",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_TERMINAL_VOLTAGE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_DEVICE_NAME",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_DCB_COUNT",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_RSOC_REAL",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_ASOC",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_FCC",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_RC",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_MAX_DCB_CELL_TEMPERATURE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_MIN_DCB_CELL_TEMPERATURE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_DCB_ALL_CELL_TEMPERATURES",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_DCB_ALL_CELL_VOLTAGES",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_READY_FOR_SHUTDOWN",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_INFO",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_TRAINING_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_USABLE_CAPACITY",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_USABLE_REMAINING_CAPACITY",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_DCB_INFO",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_SPECIFICATION",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_INTERNALS",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_BAT_REQ_TOTAL_USE_TIME",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_TOTAL_DISCHARGE_TIME",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_BAT_REQ_DEVICE_STATE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_SYS_REQ_IS_SYSTEM_REBOOTING",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_WB_REQ_STATUS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_CONNECTED_DEVICES",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_ENERGY_ALL",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_ENERGY_SOLAR",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_SOC",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_STATUS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_ERROR_CODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_APP_SOFTWARE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_BOOTLOADER_SOFTWARE",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_HW_VERSION",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_FLASH_VERSION",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_DEVICE_ID",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_DEVICE_STATE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_POWER_L1",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_POWER_L2",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_POWER_L3",
+                "interval": "S"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_ACTIVE_PHASES",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_MODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_ENERGY_L1",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_ENERGY_L2",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_ENERGY_L3",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_DEVICE_ID",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_ERROR_CODE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_DEVICE_STATE",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_FIRMWARE_VERSION",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_DIAG_INFOS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_DIAG_WARNINGS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_DIAG_ERRORS",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_DIAG_TEMP_1",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_DIAG_TEMP_2",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PM_MAX_PHASE_POWER",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_DEVICE_NAME",
+                "interval": "L"
+            },
+            {
+                "tag": "TAG_WB_REQ_EXTERN_DATA_SUN",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_EXTERN_DATA_NET",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_EXTERN_DATA_ALL",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_EXTERN_DATA_ALG",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PARAM_1",
+                "interval": "M"
+            },
+            {
+                "tag": "TAG_WB_REQ_PARAM_2",
+                "interval": "M"
+            }
+        ],
+        "polling_interval_short": 30,
+        "polling_interval_medium": 5,
+        "polling_interval_long": 12,
+        "setpower_interval": 10,
+        "send_tuple_delay": 10,
+        "query_bat": "true",
+        "query_ems": "true",
+        "query_ep": "true",
+        "query_pvi": "true",
+        "query_sys": "true",
+        "query_wb": "true",
+        "query_db": "true"
     },
-    "desc": {
-      "en": "Control E3/DC power station using RSCP protocol",
-      "de": "Steuern Sie das E3/DC-Kraftwerk mithilfe des RSCP-Protokolls",
-      "ru": "Управление электростанцией E3/DC по протоколу RSCP",
-      "pt": "Controle da estação de energia E3/DC usando o protocolo RSCP",
-      "nl": "Bedien de E3/DC-krachtcentrale met behulp van het RSCP-protocol",
-      "fr": "Contrôlez la centrale électrique E3/DC en utilisant le protocole RSCP",
-      "it": "Controllare la centrale E3/DC utilizzando il protocollo RSCP",
-      "es": "Control de la central eléctrica E3/DC mediante protocolo RSCP",
-      "pl": "Sterowanie elektrownią E3/DC za pomocą protokołu RSCP",
-      "zh-cn": "使用RSCP协议控制E3/DC电站"
-    },
-    "authors": [
-      "Ulrich Kick <iobroker@kick-web.de>"
-    ],
-    "keywords": [
-      "E3/DC",
-      "power station",
-      "energy",
-      "RSCP"
-    ],
-    "license": "GPL-3.0-only",
-    "platform": "Javascript/Node.js",
-    "main": "main.js",
-    "icon": "e3dc-rscp.png",
-    "enabled": true,
-    "extIcon": "https://raw.githubusercontent.com/git-kick/ioBroker.e3dc-rscp/master/admin/e3dc-rscp.png",
-    "readme": "https://github.com/git-kick/ioBroker.e3dc-rscp/blob/master/README.md",
-    "loglevel": "info",
-    "mode": "daemon",
-    "type": "energy",
-    "compact": true,
-    "connectionType": "local",
-    "dataSource": "poll",
-    "materialize": true,
-    "materializeTab": false,
-    "dependencies": [
-      {
-        "js-controller": ">=2.0.0"
-      }
-    ]  
-  },
-  "native": {
-    "e3dc_ip": "192.168.178.1",
-    "e3dc_port": 5033,
-    "rscp_password": "",
-    "portal_user": "",
-    "portal_password": "",
-    "polling_intervals": [
-      {
-        "tag": "TAG_EMS_REQ_POWER_PV",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_BAT",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_HOME",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_GRID",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_ADD",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_AUTARKY",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_SELF_CONSUMPTION",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_BAT_SOC",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_COUPLING_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_STORED_ERRORS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_MODE",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_BALANCED_PHASES",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_INSTALLED_PEAK_POWER",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_EMS_REQ_DERATE_AT_PERCENT_VALUE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_EMS_REQ_DERATE_AT_POWER_VALUE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_WB_ALL",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_WB_SOLAR",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_EXT_SRC_AVAILABLE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_EMS_REQ_STATUS",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EMS_REQ_USED_CHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_BAT_CHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_DCDC_CHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_USER_CHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_USED_DISCHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_BAT_DISCHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_DCDC_DISCHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_USER_DISCHARGE_LIMIT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_REMAINING_BAT_CHARGE_POWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_REMAINING_BAT_DISCHARGE_POWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_EMERGENCY_POWER_STATUS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_BATTERY_TO_CAR_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_BATTERY_BEFORE_CAR_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_GET_IDLE_PERIODS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_GET_POWER_SETTINGS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_GET_MANUAL_CHARGE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_EMERGENCYPOWER_TEST_STATUS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_GET_SYS_SPECS",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_EMS_REQ_POWER_PV_AC_OUT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EMS_REQ_ALIVE",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_EP_REQ_IS_READY_FOR_SWITCH",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EP_REQ_IS_GRID_CONNECTED",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EP_REQ_IS_ISLAND_GRID",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EP_REQ_IS_INVALID_STATE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EP_REQ_IS_POSSIBLE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_EP_REQ_EP_RESERVE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_ON_GRID",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_STATE",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_PVI_REQ_LAST_ERROR",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_TYPE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_PVI_REQ_VOLTAGE_MONITORING",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_FREQUENCY_UNDER_OVER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_SYSTEM_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_POWER_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_TEMPERATURE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_TEMPERATURE_COUNT",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_PVI_REQ_MAX_TEMPERATURE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_MIN_TEMPERATURE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_DEVICE_STATE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_SERIAL_NUMBER",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_PVI_REQ_VERSION",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_MAX_PHASE_COUNT",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_POWER",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_VOLTAGE",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_CURRENT",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_APPARENTPOWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_REACTIVEPOWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_ENERGY_ALL",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_MAX_APPARENTPOWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_AC_ENERGY_GRID_CONSUMPTION",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_DC_POWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_DC_VOLTAGE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_DC_CURRENT",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_PVI_REQ_DC_STRING_ENERGY_ALL",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_INFO",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_MAX_BAT_VOLTAGE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_MAX_CHARGE_CURRENT",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_EOD_VOLTAGE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_MAX_DISCHARGE_CURRENT",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_CHARGE_CYCLES",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_TERMINAL_VOLTAGE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_DEVICE_NAME",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_DCB_COUNT",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_RSOC_REAL",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_ASOC",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_FCC",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_RC",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_MAX_DCB_CELL_TEMPERATURE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_MIN_DCB_CELL_TEMPERATURE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_DCB_ALL_CELL_TEMPERATURES",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_DCB_ALL_CELL_VOLTAGES",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_READY_FOR_SHUTDOWN",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_INFO",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_TRAINING_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_USABLE_CAPACITY",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_USABLE_REMAINING_CAPACITY",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_DCB_INFO",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_SPECIFICATION",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_INTERNALS",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_BAT_REQ_TOTAL_USE_TIME",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_TOTAL_DISCHARGE_TIME",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_BAT_REQ_DEVICE_STATE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_SYS_REQ_IS_SYSTEM_REBOOTING",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_WB_REQ_STATUS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_CONNECTED_DEVICES",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_ENERGY_ALL",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_ENERGY_SOLAR",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_SOC",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_STATUS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_ERROR_CODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_APP_SOFTWARE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_BOOTLOADER_SOFTWARE",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_HW_VERSION",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_FLASH_VERSION",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_DEVICE_ID",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_DEVICE_STATE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_POWER_L1",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_POWER_L2",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_POWER_L3",
-        "interval": "S"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_ACTIVE_PHASES",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_MODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_ENERGY_L1",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_ENERGY_L2",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_ENERGY_L3",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_DEVICE_ID",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_ERROR_CODE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_DEVICE_STATE",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_FIRMWARE_VERSION",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_DIAG_INFOS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_DIAG_WARNINGS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_DIAG_ERRORS",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_DIAG_TEMP_1",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_DIAG_TEMP_2",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PM_MAX_PHASE_POWER",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_DEVICE_NAME",
-        "interval": "L"
-      },
-      {
-        "tag": "TAG_WB_REQ_EXTERN_DATA_SUN",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_EXTERN_DATA_NET",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_EXTERN_DATA_ALL",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_EXTERN_DATA_ALG",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PARAM_1",
-        "interval": "M"
-      },
-      {
-        "tag": "TAG_WB_REQ_PARAM_2",
-        "interval": "M"
-      }
-    ],
-    "polling_interval_short": 30,
-    "polling_interval_medium": 5,
-    "polling_interval_long": 12,
-    "setpower_interval": 10,
-    "send_tuple_delay": 10,
-    "query_bat": "true",
-    "query_ems": "true",
-    "query_ep": "true",
-    "query_pvi": "true",
-    "query_sys": "true",
-    "query_wb": "true",
-    "query_db": "true"
-  },
-  "objects": [],
-  "instanceObjects": []
+    "objects": [],
+    "instanceObjects": []
 }

--- a/io-package.json
+++ b/io-package.json
@@ -575,6 +575,10 @@
         "interval": "M"
       },
       {
+        "tag": "TAG_WB_REQ_CONNECTED_DEVICES",
+        "interval": "M"
+      },
+      {
         "tag": "TAG_WB_REQ_ENERGY_ALL",
         "interval": "M"
       },

--- a/io-package.json
+++ b/io-package.json
@@ -339,6 +339,10 @@
                 "interval": "M"
             },
             {
+                "tag": "TAG_EP_REQ_EP_RESERVE",
+                "interval": "S"
+            },
+            {
                 "tag": "TAG_PVI_REQ_ON_GRID",
                 "interval": "M"
             },

--- a/io-package.json
+++ b/io-package.json
@@ -340,7 +340,7 @@
       },
       {
         "tag": "TAG_EP_REQ_EP_RESERVE",
-        "interval": "S"
+        "interval": "M"
       },
       {
         "tag": "TAG_PVI_REQ_ON_GRID",
@@ -453,6 +453,10 @@
       {
         "tag": "TAG_PVI_REQ_DC_STRING_ENERGY_ALL",
         "interval": "M"
+      },
+      {
+        "tag": "TAG_BAT_REQ_INFO",
+        "interval": "L"
       },
       {
         "tag": "TAG_BAT_REQ_MAX_BAT_VOLTAGE",

--- a/main.js
+++ b/main.js
@@ -588,7 +588,10 @@ class E3dcRscp extends utils.Adapter {
 			return;
 		}
 		const tagCode = rscpTagCode[tag];
-		if( this.pollingInterval[tagCode] == "" && tag.contains("_REQ_") ) {
+		if( tag.includes("TAG_EP_REQ_") ) {
+			this.log.info(`addTagtoFrame( ${tag}, ${sml} )`);
+		}
+		if( typeof this.pollingInterval[tagCode] === "undefined" && tag.includes("_REQ_") ) {
 			this.log.warn(`${tag} has no assigned polling interval  - assuming 'M' - assignment should be added to io-package.json`);
 			this.pollingInterval[tagCode] == "M";
 		}

--- a/main.js
+++ b/main.js
@@ -588,9 +588,9 @@ class E3dcRscp extends utils.Adapter {
 			return;
 		}
 		const tagCode = rscpTagCode[tag];
-		if( typeof this.pollingInterval[tagCode] === "undefined" && tag.includes("_REQ_") && !tag.endsWith("_COUNT") ) {
+		if( sml != "" && !Object.keys(this.pollingInterval).includes(tagCode) && tag.includes("_REQ_") && !tag.endsWith("_COUNT") ) {
 			this.log.warn(`${tag} has no assigned polling interval  - assuming 'M' - please check io-package.json`);
-			this.pollingInterval[tagCode] == "M";
+			this.pollingInterval[tagCode] = "M";
 		}
 		if( sml == "" || this.pollingInterval[tagCode] == sml ) {
 			const typeCode = parseInt( rscpTag[tagCode].DataTypeHex, 16 );
@@ -703,7 +703,7 @@ class E3dcRscp extends utils.Adapter {
 			return 0;
 		}
 		const tagCode = rscpTagCode[tag];
-		if( sml == "" || this.pollingInterval[tagCode] == "" || this.pollingInterval[tagCode] == sml ) {
+		if( sml == "" || !Object.keys(this.pollingInterval).includes(tagCode) || this.pollingInterval[tagCode] == sml ) {
 			const typeCode = parseInt( rscpTag[tagCode].DataTypeHex, 16 );
 			if( rscpType[typeCode] != "Container") {
 				this.log.warn(`Non-container tag ${tag} passed to startContainer - cannot start container.`);

--- a/main.js
+++ b/main.js
@@ -588,11 +588,8 @@ class E3dcRscp extends utils.Adapter {
 			return;
 		}
 		const tagCode = rscpTagCode[tag];
-		if( tag.includes("TAG_EP_REQ_") ) {
-			this.log.info(`addTagtoFrame( ${tag}, ${sml} )`);
-		}
 		if( typeof this.pollingInterval[tagCode] === "undefined" && tag.includes("_REQ_") ) {
-			this.log.warn(`${tag} has no assigned polling interval  - assuming 'M' - assignment should be added to io-package.json`);
+			this.log.warn(`${tag} has no assigned polling interval  - assuming 'M' - please check io-package.json`);
 			this.pollingInterval[tagCode] == "M";
 		}
 		if( sml == "" || this.pollingInterval[tagCode] == sml ) {

--- a/main.js
+++ b/main.js
@@ -588,7 +588,7 @@ class E3dcRscp extends utils.Adapter {
 			return;
 		}
 		const tagCode = rscpTagCode[tag];
-		if( typeof this.pollingInterval[tagCode] === "undefined" && tag.includes("_REQ_") ) {
+		if( typeof this.pollingInterval[tagCode] === "undefined" && tag.includes("_REQ_") && !tag.endsWith("_COUNT") ) {
 			this.log.warn(`${tag} has no assigned polling interval  - assuming 'M' - please check io-package.json`);
 			this.pollingInterval[tagCode] == "M";
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.e3dc-rscp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
           "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
           "dev": true,
           "requires": {
-            "follow-redirects": "^1.14.8"
+            "follow-redirects": "^1.14.0"
           }
         }
       }
@@ -107,6 +107,58 @@
         "mocha": "^9.1.3",
         "sinon": "^12.0.1",
         "sinon-chai": "^3.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-8.1.0.tgz",
+          "integrity": "sha512-OAPJUAtgeINhh/TAlUID4QTs53Njm7xzddaVlEs/SXwgtiD1tW22zAB/W1wdqfrpmikgaWQ9Fw6Ws+hsiRm5Vg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "alcalzone-shared": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/alcalzone-shared/-/alcalzone-shared-4.0.8.tgz",
+          "integrity": "sha512-Rr0efCjNL9lw7miDvU8exL87Y42ehsLU2jUGNQUphhnlvxnTMrHeApWgoOSGZvsE2PhxC3KO7Z+VpQ/IbuV3aA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "sinon": {
+          "version": "12.0.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-12.0.1.tgz",
+          "integrity": "sha512-iGu29Xhym33ydkAT+aNQFBINakjq69kKO6ByPvTsm3yyIACfyQttRTP03aBP/I8GfhFmLzrnKwNNkr0ORb1udg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.8.3",
+            "@sinonjs/fake-timers": "^8.1.0",
+            "@sinonjs/samsam": "^6.0.2",
+            "diff": "^5.0.0",
+            "nise": "^5.1.0",
+            "supports-color": "^7.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "@selderee/plugin-htmlparser2": {
@@ -653,7 +705,7 @@
       "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.4"
       }
     },
     "bach": {
@@ -875,7 +927,7 @@
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
         "fsevents": "~2.3.2",
-        "glob-parent": ">=5.1.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
@@ -1857,9 +1909,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "for-in": {
@@ -1998,7 +2050,7 @@
       "requires": {
         "extend": "^3.0.0",
         "glob": "^7.1.1",
-        "glob-parent": ">=5.1.2",
+        "glob-parent": "^3.1.0",
         "is-negated-glob": "^1.0.0",
         "ordered-read-streams": "^1.0.0",
         "pumpify": "^1.3.5",
@@ -2009,9 +2061,9 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": ">=5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "dev": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -2021,7 +2073,7 @@
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
@@ -2107,6 +2159,29 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+              "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+              "dev": true,
+              "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                  "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
+              }
+            }
           }
         },
         "extend-shallow": {
@@ -2141,17 +2216,14 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "^4.0.1"
           },
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
               "requires": {
                 "is-extglob": "^2.1.0"
               }
@@ -2544,7 +2616,7 @@
         "deepmerge": "^4.2.2",
         "he": "^1.2.0",
         "htmlparser2": "^6.1.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.5",
         "selderee": "^0.6.0"
       }
     },
@@ -2738,8 +2810,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -3263,7 +3334,7 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": ">=3.1.31",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.e3dc-rscp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Control E3/DC power station via RSCP",
   "author": {
     "name": "Ulrich Kick",


### PR DESCRIPTION
* No updates for e3dc-rscp.0.EP.PARAM_0.* - [Issue #117](https://github.com/git-kick/ioBroker.e3dc-rscp/issues/117)

__Note__: DO NOT import adapter settings from a json-file created with an older version of e3dc-rscp. Instead, create a new adapter configuration from the scratch and then store it to a json-file. Reason is that importing an older json-file will delete polling interval list entries which have been added with v1.0.8 and this will invalidate the bugfix!