### PR TITLE
No existing objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Here is a sample script for charge limit control - it is not meant for as-is usa
 (git-kick)
 * No updates for e3dc-rscp.0.EP.PARAM_0.* - [Issue #117](https://github.com/git-kick/ioBroker.e3dc-rscp/issues/117)
 * Vulnerable dependency: glob-parent < 5.1.2 - [CVE-2020-28469](https://nvd.nist.gov/vuln/detail/CVE-2020-28469)
-
+* Define RSCP.AUTHENTICATION (avoid warning in log)
 
 __Note__: DO NOT import adapter settings from a json-file created with an older version of e3dc-rscp. Instead, create a new adapter configuration from the scratch and then store it to a json-file. Reason is that importing an older json-file will delete polling interval list entries which have been added with v1.0.8 and this will invalidate the bugfix!
 ### 1.0.7

--- a/main.js
+++ b/main.js
@@ -1594,11 +1594,15 @@ class E3dcRscp extends utils.Adapter {
 		// Statically, we define only one device per supported RSCP namespace,
 		// plus some setter objects which would not appear before first setting.
 		// The rest of the object tree is defined dynamically.
+		//
 		this.language = "en";
 		this.getForeignObject("system.config", (err, systemConfig) => {
 			if( systemConfig ) this.language = systemConfig.common.language;
 		});
-		await this.setObjectNotExistsAsync("info", {
+		// For some objects, we use setObjectNotExists instead of setObjectNotExistsAsync
+		// to avoid "has no existing objects" warning in the adapter log
+		//
+		await this.setObjectNotExists("info", {
 			type: "channel",
 			common: {
 				name: systemDictionary["Information"][this.language],
@@ -1606,7 +1610,7 @@ class E3dcRscp extends utils.Adapter {
 			},
 			native: {},
 		});
-		await this.setObjectNotExistsAsync("info.connection", {
+		await this.setObjectNotExists("info.connection", {
 			type: "state",
 			common: {
 				name: systemDictionary["Connected"][this.language],
@@ -1625,7 +1629,7 @@ class E3dcRscp extends utils.Adapter {
 			},
 			native: {},
 		});
-		await this.setObjectNotExistsAsync( "RSCP.AUTHENTICATION", {
+		await this.setObjectNotExists( "RSCP.AUTHENTICATION", {
 			type: "state",
 			common: {
 				name: systemDictionary["AUTHENTICATION"][this.language],

--- a/main.js
+++ b/main.js
@@ -1617,7 +1617,7 @@ class E3dcRscp extends utils.Adapter {
 			},
 			native: {},
 		});
-		await this.setObjectNotExistsAsync("RSCP", {
+		await this.setObjectNotExists("RSCP", {
 			type: "device",
 			common: {
 				name: systemDictionary["RSCP"][this.language],

--- a/main.js
+++ b/main.js
@@ -1625,6 +1625,18 @@ class E3dcRscp extends utils.Adapter {
 			},
 			native: {},
 		});
+		await this.setObjectNotExistsAsync( "RSCP.AUTHENTICATION", {
+			type: "state",
+			common: {
+				name: systemDictionary["AUTHENTICATION"][this.language],
+				type: "number",
+				role: "value",
+				read: true,
+				write: false,
+				unit: rscpTag[rscpTagCode["TAG_RSCP_AUTHENTICATION"]].Unit,
+			},
+			native: {},
+		});
 		if( this.config.query_bat ) {
 			await this.setObjectNotExistsAsync("BAT", {
 				type: "device",


### PR DESCRIPTION
Depending on timing, info.connection and RSCP.AUTHENTICATION caused warnings like "has no existing object, might lead to an error in future versions".
Both objects are now defined synchronously to fix that.