### PR TITLE
Update README.md - copyright line fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,10 +627,11 @@ __Note__: DO NOT import adapter settings from a json-file created with an older 
 * Adapter review (PR#1589): onUnload(), clear _all_ timers and close TCP connection
 * Remove Sentry, because it was only a trial and not properly configured
 
-Copyright (c) 2024 Ulrich Kick <iobroker@kick-web.de>
-
 <a name="lic"></a>
 ## License
+
+Copyright (c) 2024 Ulrich Kick <iobroker@kick-web.de>
+
 ```
 					GNU GENERAL PUBLIC LICENSE
 					   Version 3, 29 June 2007


### PR DESCRIPTION
The copyright line must be located within the license section.
The first copyright line within the license sectio n is evaluated in respect to the copyright year.

Please see template fiels if required.

This PR should fix the checker issue by placing the copyright line as first copyright line into license section.