### PR TITLE
added (empty) gcommon.globalDependencies

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -188,6 +188,8 @@
                 "js-controller": ">=5.0.19"
             }
         ],
+        "globalDependencies": [
+        ],
         "plugins": {
             "sentry": {
                 "dsn": "https://cc70dc76ca0d4bc89be51866648d109c@o1065834.ingest.sentry.io/6058026"


### PR DESCRIPTION
because ioBroker Check and Service Bot reported:
[E186] "common.globalDependencies" must be an array at [io-package.json](https://github.com/git-kick/ioBroker.e3dc-rscp/blob/master/io-package.json)