### PR TITLE
E190: added admin dependency

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -185,10 +185,11 @@
         },
         "dependencies": [
             {
-                "js-controller": ">=5.0.19"
+                "js-controller": ">=5.0.19",
+                "admin": ">=7.4.10"
             }
         ],
-        "plugins": {
+            "plugins": {
             "sentry": {
                 "dsn": "https://cc70dc76ca0d4bc89be51866648d109c@o1065834.ingest.sentry.io/6058026"
             }

--- a/io-package.json
+++ b/io-package.json
@@ -189,7 +189,6 @@
                 "admin": ">=7.4.10"
             }
         ],
-            "plugins": {
         "globalDependencies": [
         ],
         "plugins": {


### PR DESCRIPTION
because ioBroker Check and Service Bot reported:
[E190] admin dependency missing. admin 6.17.14 is required as minimum, 7.4.10 is recommended. Please add to dependencies at [io-package.json](https://github.com/git-kick/ioBroker.e3dc-rscp/blob/master/io-package.json).